### PR TITLE
Update azuredeploy.json

### DIFF
--- a/IaaS-NSG-UDR-Before/azuredeploy.json
+++ b/IaaS-NSG-UDR-Before/azuredeploy.json
@@ -114,7 +114,6 @@
     },
     "prmStorageName": {
       "type": "string",
-      "maxValue": 10,
       "metadata": {
         "description": "Name prefix for simple storage account."
       }


### PR DESCRIPTION
Removed max value for prmStorageName parameter.  Azure errored out saying only int types could have min/max values and it's a string.
